### PR TITLE
Fix to support NumPy 2

### DIFF
--- a/PVForecast/dwdforecast.py
+++ b/PVForecast/dwdforecast.py
@@ -206,7 +206,7 @@ class DWDForecast(Forecast):
                     valStr = valStrArray[i].text.replace('-', 'nan')
                     valArr = valStr.split()
                     valArr = np.array(valArr)
-                    valArr = np.asfarray(valArr, float)
+                    valArr = np.asarray(valArr, dtype=float)
                     weatherData.update({ param : valArr })
                 self.DataTable            = pd.DataFrame(weatherData, index=pd.DatetimeIndex(PeriodEnd))
                 self.DataTable.index.name = 'PeriodEnd'                                  # Time is in UTC


### PR DESCRIPTION
`np.asfarray` was removed in the NumPy 2.0 release. Use `np.asarray` with a proper dtype instead.

Fixes #35